### PR TITLE
rename era2->e2ss and add contact info for era1+e2ss

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Adding a mainnet endpoint involes appending endpoint data to [`endpoints/mainnet
 ```yaml
 - endpoint: https://history-sync.example.com
   name: example.com
-  format: era2
+  format: e2ss
   torrent: false
   notes:
     - name: "Status page"
@@ -85,7 +85,7 @@ Adding a mainnet endpoint involes appending endpoint data to [`endpoints/mainnet
 ```yaml
 - endpoint: https://history-sync.example.com
   name: example.com
-  format: era2
+  format: e2ss
   torrent: true
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Ethereum Historical Data Endpoints
 
-This page contains a **community-maintained list of Ethereum historical data endpoints**, including **Era1, Era, Era2 files, and torrents**.
+This page contains a **community-maintained list of Ethereum historical data endpoints**, including **Era1, Era, E2ss files, and torrents**.
 
 > ⚠️ This list should not be treated as a single source of truth for these endpoints, or the data they provide. It is a **community-maintained list**, and as such, some endpoints listed here may not be up to date, or may not provide the data they claim to be providing.
 
 Historical data providers offer **three primary storage formats**:
 - **Era1**(Pre-Merge) - Archive nodes providing **execution layer history** before The Merge (ETH1).
 - **Era**(Post-Merge) - Execution layer history **from The Merge onward**, including historical block data.
-- **Era2**(State) - **State snapshots** for execution clients.
+- **E2ss**(State) - **State snapshots** for execution clients.
 - **Erb**(Blob) - Era file equivalent for blob sidecars [ ⚠️ Under Development ].
 
 This registry is designed to **reduce reliance on centralized providers** by creating a **publicly accessible, decentralized list of historical data sources**. It aligns with **EIP-4444** and **Portal Network** efforts to ensure that Ethereum clients can obtain block history **beyond what traditional p2p sync provides**.

--- a/endpoints/mainnet.yaml
+++ b/endpoints/mainnet.yaml
@@ -16,7 +16,17 @@
   name: EF DevOps
   format: era1
   torrent: false
+  contacts:
+    - name: "EF DevOps"
+      link: mailto:devops@ethererum.org
+    - name: "@KolbyML"
+      link: https://x.com/Kolby_ML      
 - endpoint: https://era2.ethportal.net
   name: EF DevOps
-  format: era2
+  format: e2ss
   torrent: false
+  contacts:
+    - name: "EF DevOps"
+      link: mailto:devops@ethererum.org
+    - name: "@KolbyML"
+      link: https://x.com/Kolby_ML 

--- a/index.md
+++ b/index.md
@@ -2,14 +2,14 @@
 layout: default
 ---
 
-This page contains a **community-maintained list of Ethereum historical data endpoints**, including **Era1, Era, Era2 files, and torrents**.
+This page contains a **community-maintained list of Ethereum historical data endpoints**, including **Era1, Era, E2ss files, and torrents**.
 
 > ⚠️ This list should not be treated as a single source of truth for these endpoints, or the data they provide. It is a **community-maintained list**, and as such, some endpoints listed here may not be up to date, or may not provide the data they claim to be providing.
 
 Historical data providers offer **three primary storage formats**:
 - **Era1** [Spec](https://github.com/ethereum/go-ethereum/pull/26621#issue-1573139029) - Execution layer historical block data **before The Merge**.
 - **Era** [Spec](https://github.com/status-im/nimbus-eth2/blob/613f4a9a50c9c4bd8568844eaffb3ac15d067e56/docs/e2store.md#era-files) - Consensys layer historical block data **from The Merge onward**.
-- **Era2** [Spec](https://github.com/ethereum/trin/blob/62dd518a88eda8496f89db9f9c149231a2c326dc/e2store/src/era2.rs#L24-L37) - **State snapshots** for execution clients.
+- **E2ss** [Spec](https://github.com/ethereum/trin/blob/62dd518a88eda8496f89db9f9c149231a2c326dc/e2store/src/era2.rs#L24-L37) - **State snapshots** for execution clients.
 - **Erb** [Spec](https://github.com/status-im/nimbus-eth2/pull/5882) - Era file equivalent for blob sidecars [ ⚠️ Under Development ].
 
 This registry is designed to **reduce reliance on centralized providers** by creating a **publicly accessible, decentralized list of historical data sources**. It aligns with **EIP-4444** and **Portal Network** efforts to ensure that Ethereum clients can obtain block history **beyond what traditional p2p sync provides**.

--- a/schema.yaml
+++ b/schema.yaml
@@ -2,7 +2,7 @@ list(include('endpoint'))
 ---
 endpoint:
   endpoint: str(matches='^(http|https)://.*', ignore_case=True)
-  format: str(matches='^(era|era1|era2|erb)$', ignore_case=True)
+  format: str(matches='^(era|era1|e2ss|erb)$', ignore_case=True)
   name: str()
   torrent: bool(required=False)
   contacts: list(include('contact'), min=0, max=5, required=False)


### PR DESCRIPTION
@advaita-saha 

So I talked with @arnetheduck and we will be renaming `era2` to `e2ss` for 2 reasons
- so `era` will be reserved for Ethereum chain history whether that is EL/CL/Both
- era2 store didn't follow the era format, era refers to a period of 8192 blocks or slots, era2 was a 1 block snapshot of the state.

I also added contact info for EF Devops and me